### PR TITLE
Quality of Life Updates

### DIFF
--- a/.github/workflows/test_main.yml
+++ b/.github/workflows/test_main.yml
@@ -20,22 +20,16 @@ jobs:
         shell: bash -l {0}
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-    - name: Install dependencies
+    - name : Remove CUDA if Mac
+      if: startsWith(matrix.os, 'macos')
       run: |
-        # $CONDA is an environment variable pointing to the root of the miniconda directory
-        $CONDA/bin/conda env update --file environment.yml --name base
-    - name: Test with pytest
-      run: |
-        $CONDA/bin/pytest src/ -m "not needs_gpu"
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+        sed '/cuda/d' environment.yml | tee environment.yml
+    - uses: conda-incubator/setup-miniconda@v2
       with:
-        file: ./coverage.xml
-        env_vars: OS,PYTHON
-        name: codecov-torch-test
-        fail_ci_if_error: false
-        verbose: true
+        activate-environment: torch
+        environment-file: environment.yml
+        python-version: ${{ matrix.python-version }}
+        auto-activate-base: false
+    - name: Test pytorch with pytest
+      run: |
+        pytest src -m "not needs_gpu"

--- a/.github/workflows/test_main.yml
+++ b/.github/workflows/test_main.yml
@@ -23,7 +23,7 @@ jobs:
         $CONDA/bin/conda env update --file environment.yml --name base
     - name: Test with pytest
       run: |
-        $CONDA/bin/pytest src/ -s -v -m "not needs_gpu" --cov=src/ --cov-report=xml
+        $CONDA/bin/pytest src/ -m "not needs_gpu"
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:

--- a/.github/workflows/test_main.yml
+++ b/.github/workflows/test_main.yml
@@ -6,8 +6,12 @@ on:
   pull_request:
     branches: [ master ]
 jobs:
-  build-linux:
-    runs-on: ubuntu-20.04
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, ubuntu-18.04, windows-latest, macos-latest]
+        python-version: [3.9]
     env:
       OS: 'ubuntu-20.04'
       PYTHON: '3.8'

--- a/.github/workflows/test_main.yml
+++ b/.github/workflows/test_main.yml
@@ -13,8 +13,11 @@ jobs:
         os: [ubuntu-20.04, ubuntu-18.04, windows-latest, macos-latest]
         python-version: [3.9]
     env:
-      OS: 'ubuntu-20.04'
-      PYTHON: '3.8'
+      OS: ${{ matrix.os }}
+      PYTHON: ${{ matrix.python-version }}
+    defaults:
+      run:
+        shell: bash -l {0}
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.8

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,7 @@
 name: torch
 channels:
   - conda-forge
+  - pytorch
 dependencies:
   - cudatoolkit=11.2
   - pip=21.3

--- a/environment.yml
+++ b/environment.yml
@@ -2,11 +2,10 @@ name: torch
 channels:
   - conda-forge
 dependencies:
-  - cudatoolkit=11.1
-  - pip=21.0.1
-  - pytest=6.1.1
-  - pytest-cov=2.10.1
-  - python=3.8
-  - pytorch=1.8.0
-  - requests=2.25.1
-  - torchvision=0.9.0
+  - cudatoolkit=11.2
+  - pip=21.3
+  - pytest=6.2
+  - python=3.9
+  - pytorch=1.10
+  - requests=2.26
+  - torchvision=0.10

--- a/environment.yml
+++ b/environment.yml
@@ -2,6 +2,8 @@ name: torch
 channels:
   - conda-forge
   - pytorch
+  - anaconda
+  - defaults
 dependencies:
   - cudatoolkit=11.2
   - pip=21.3

--- a/environment.yml
+++ b/environment.yml
@@ -6,9 +6,9 @@ channels:
   - defaults
 dependencies:
   - cudatoolkit=11.2
-  - pip=21.3
-  - pytest=6.2
+  - pip
+  - pytest
   - python=3.9
   - pytorch=1.10
-  - requests=2.26
-  - torchvision=0.10
+  - requests
+  - torchvision=0.11

--- a/environment.yml
+++ b/environment.yml
@@ -1,9 +1,6 @@
 name: torch
 channels:
-  - pytorch
-  - anaconda
   - conda-forge
-  - defaults
 dependencies:
   - cudatoolkit=11.1
   - pip=21.0.1


### PR DESCRIPTION
- Move `conda-forge` to the top priority channel. This should allow building of environment on M1 Mac
- Reduce, relax and version bump dependencies
- Use `setup-miniconda` for managing conda environment
- Test builds on Ubuntu (18.04, 20.04), Windows and MacOS